### PR TITLE
Rename lmdb-delete to lmdb-delete-database

### DIFF
--- a/lmdb.scm
+++ b/lmdb.scm
@@ -63,6 +63,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
          lmdb-index-first
          lmdb-index-next
          lmdb-delete
+         lmdb-delete-database
          lmdb-set!
          lmdb-ref
          lmdb-count
@@ -480,7 +481,12 @@ END
 
 
 (define (lmdb-delete fname)
-  (lmdb-log 2 "lmdb-delete ~A~%" fname)
+  (abort
+   (make-property-condition 'exn
+    'message "lmdb-delete is deprecated, use lmdb-delete-database instead")))
+
+(define (lmdb-delete-database fname)
+  (lmdb-log 2 "lmdb-delete-database ~A~%" fname)
   (if (file-exists? fname) (begin
      (delete-file (make-pathname fname "data.mdb"))
      (delete-file (make-pathname fname "lock.mdb"))
@@ -654,7 +660,7 @@ END
 
 (define (hash-table->lmdb t mfile . key)
   (lmdb-log 2 "table->lmdb ~A ~A ~A~%" t mfile key)
-  (lmdb-delete mfile)
+  (lmdb-delete-database mfile)
   (let ((s (apply lmdb-open (append (list mfile) key))))
     (hash-table-for-each t (lambda (k v) (lmdb-set! s (string->blob (symbol->string k)) v)))
     (lmdb-close s) #t))

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -18,7 +18,7 @@
 (test-group "lmdb encrypted key-value creation and lookup"
             (test-assert
              (let* ((fname (make-pathname "." "unittest.mdb")))
-               (lmdb-delete fname)
+               (lmdb-delete-database fname)
                (let* ((keys (list "k1" 'k2 '(k3)))
                       (values (list 'one 2 "three"))
                       (cryptokey (random-blob 24))
@@ -39,7 +39,7 @@
                        )
                    (lmdb-end mm)
                    (lmdb-close mm)
-                   (lmdb-delete fname)
+                   (lmdb-delete-database fname)
                    res)
                  ))
              ))
@@ -48,7 +48,7 @@
 (test-group "lmdb unencrypted key-value creation and lookup"
             (test-assert
              (let* ((fname (make-pathname "." "unittest.mdb")))
-               (lmdb-delete fname)
+               (lmdb-delete-database fname)
                (let* ((keys (list "k1" 'k2 '(k3)))
                       (values (list 'one 2 "three"))
                       (mm (lmdb-open fname)))
@@ -68,14 +68,14 @@
                         )
                    (lmdb-end mm)
                    (lmdb-close mm)
-                   (lmdb-delete fname)
+                   (lmdb-delete-database fname)
                    res)
                  ))
              ))
 
 (test-group "lmdb unencrypted key-value creation and fold / for-each"
              (let* ((fname (make-pathname "." "unittest.mdb")))
-               (lmdb-delete fname)
+               (lmdb-delete-database fname)
                (let* ((keys (list "k1" 'k2 '(k3)))
                       (values (list 'one 2 "three"))
                       (mm (lmdb-open fname)))
@@ -101,14 +101,14 @@
                               (list 'k2 "k1" '(k3))
                               (list 2 'one "three"))))
                  (lmdb-close mm)
-                 (lmdb-delete fname)
+                 (lmdb-delete-database fname)
                  ))
              )
 
 
 (test-group "lmdb unencrypted key-value creation and conversion to/from hash tables"
              (let* ((fname (make-pathname "." "unittest.mdb")))
-               (lmdb-delete fname)
+               (lmdb-delete-database fname)
                (let* ((keys (list "k1" 'k2 '(k3)))
                       (values (list 'one 2 "three"))
                       (mm (lmdb-open fname)))
@@ -126,7 +126,7 @@
                    ;      (map (lambda (k v) (cons (string->blob (->string k)) (string->blob (->string v)))) 
                    ;           (list 'k2 "k1" '(k3))
                    ;           (list 2 'one "three"))))
-                 (lmdb-delete fname)
+                 (lmdb-delete-database fname)
                  ))
              )
 
@@ -134,7 +134,7 @@
 (test-group "lmdb named database creation and lookup"
             (test-assert
              (let* ((fname (make-pathname "." "unittest.mdb")))
-               (lmdb-delete fname)
+               (lmdb-delete-database fname)
                (let* ((keys (list "k1" 'k2 '(k3)))
                       (values (list 'one 2 "three"))
                       )
@@ -172,7 +172,7 @@
                             )
                        (lmdb-end mm)
                        (lmdb-close mm)
-                       (lmdb-delete fname)
+                       (lmdb-delete-database fname)
                        (and res1 res2))
                      ))
                  ))
@@ -181,7 +181,7 @@
 
 (test-group "lmdb mdb-notfound condition"
             (let* ((fname (make-pathname "." "unittest.mdb")))
-              (lmdb-delete fname)
+              (lmdb-delete-database fname)
               (let ((mm (lmdb-open fname maxdbs: 2)))
                 (lmdb-begin mm)
                 (test "condition-case for get missing key"
@@ -193,7 +193,7 @@
 
 (test-group "abort transaction"
 	    (let* ((fname (make-pathname "." "unittest.mdb")))
-              (lmdb-delete fname)
+              (lmdb-delete-database fname)
               (let ((mm (lmdb-open fname maxdbs: 2)))
                 (lmdb-begin mm)
 		;; set foo


### PR DESCRIPTION
I've included a deprecated error message for lmdb-delete (since we plan
on using lmdb-delete! for deleting keys). If you wanted to be a bit more gentle on users we could have lmdb-delete run lmdb-delete-database with a printed warning message first, but personally I prefer an exception since it's easy to fix.
