### PR TITLE
normal shebang line in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-# -*- sh -*-
+#!/bin/sh
 
 "$CHICKEN_CSI" -q -s build.scm "$CHICKEN_CSC $@"
 


### PR DESCRIPTION
```alice@bellona:~/.cache/chicken-install % chicken-install -s -purge lmdb-ht
alice@bellona:~/.cache/chicken-install % chicken-install -s lmdb-ht
building lmdb-ht
   /home/alice/.cache/chicken-install/lmdb-ht/build.sh -host -D compiling-extension -J -s -regenerate-import-libraries -setup-mode -I /home/alice/.cache/chicken-install/lmdb-ht -C -I/home/alice/.cache/chicken-install/lmdb-ht -O2 -d1 lmdb.scm -o /home/alice/.cache/chicken-i
nstall/lmdb-ht/lmdb-ht.so
executing command failed: Exec format error

Error: shell command terminated with nonzero exit code
256
"sh /home/alice/.cache/chicken-install/lmdb-ht/lmdb-ht.build.sh"
```
I didn't investigate _why_ exactly this happens when the script doesn't have a shebang line because it should just have one. chicken 5.1.0 on void